### PR TITLE
Added .NET Aspire 9.3 and Refactor project structure and integrate service defaults

### DIFF
--- a/Krosmoz.slnx
+++ b/Krosmoz.slnx
@@ -1,16 +1,23 @@
 <Solution>
-  <Folder Name="/libs/">
-    <Project Path="libs\Krosmoz.Core\Krosmoz.Core.csproj" Type="Classic C#" />
-    <Project Path="libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj" Type="Classic C#" />
-    <Project Path="libs\Krosmoz.Serialization\Krosmoz.Serialization.csproj" Type="Classic C#" />
-    <Project Path="libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" Type="Classic C#" />
-  </Folder>
-  <Folder Name="/src/">
-    <Project Path="src\Krosmoz.Servers.AuthServer\Krosmoz.Servers.AuthServer.csproj" Type="Classic C#" />
-    <Project Path="src\Krosmoz.Servers.GameServer\Krosmoz.Servers.GameServer.csproj" Type="Classic C#" />
-  </Folder>
-  <Folder Name="/tools/">
-    <Project Path="tools\Krosmoz.Tools.Database\Krosmoz.Tools.Database.csproj" Type="Classic C#" />
-    <Project Path="tools\Krosmoz.Tools.Protocol\Krosmoz.Tools.Protocol.csproj" Type="Classic C#" />
-  </Folder>
+    <Folder Name="/infrastructure/">
+        <Project Path="infrastructure\Krosmoz.Infrastructure.AppHost\Krosmoz.Infrastructure.AppHost.csproj"
+                 Type="Classic C#"/>
+        <Project
+            Path="infrastructure\Krosmoz.Infrastructure.ServiceDefaults\Krosmoz.Infrastructure.ServiceDefaults.csproj"
+            Type="Classic C#"/>
+    </Folder>
+    <Folder Name="/libs/">
+        <Project Path="libs\Krosmoz.Core\Krosmoz.Core.csproj" Type="Classic C#"/>
+        <Project Path="libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj" Type="Classic C#"/>
+        <Project Path="libs\Krosmoz.Serialization\Krosmoz.Serialization.csproj" Type="Classic C#"/>
+        <Project Path="libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" Type="Classic C#"/>
+    </Folder>
+    <Folder Name="/src/">
+        <Project Path="src\Krosmoz.Servers.AuthServer\Krosmoz.Servers.AuthServer.csproj" Type="Classic C#"/>
+        <Project Path="src\Krosmoz.Servers.GameServer\Krosmoz.Servers.GameServer.csproj" Type="Classic C#"/>
+    </Folder>
+    <Folder Name="/tools/">
+        <Project Path="tools\Krosmoz.Tools.Database\Krosmoz.Tools.Database.csproj" Type="Classic C#"/>
+        <Project Path="tools\Krosmoz.Tools.Protocol\Krosmoz.Tools.Protocol.csproj" Type="Classic C#"/>
+    </Folder>
 </Solution>

--- a/infrastructure/Krosmoz.Infrastructure.AppHost/AppHost.cs
+++ b/infrastructure/Krosmoz.Infrastructure.AppHost/AppHost.cs
@@ -1,0 +1,28 @@
+using Projects;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgresql = builder
+    .AddPostgres("postgres")
+    .WithDataVolume("postgres-data-volume");
+
+var authDatabase = postgresql.AddDatabase("auth");
+var gameDatabase = postgresql.AddDatabase("game");
+
+/*
+var databaseServer = builder.AddProject<Krosmoz_Tools_Database>("DatabaseServer")
+    .WaitFor(authDatabase)
+    .WaitFor(gameDatabase)
+    .WithReference(authDatabase)
+    .WithReference(gameDatabase);
+*/
+
+var authServer = builder.AddProject<Krosmoz_Servers_AuthServer>("AuthServer")
+    .WaitFor(authDatabase)
+    .WithReference(authDatabase);
+
+var gameServer = builder.AddProject<Krosmoz_Servers_GameServer>("GameServer")
+    .WaitFor(gameDatabase)
+    .WithReference(gameDatabase);
+
+builder.Build().Run();

--- a/infrastructure/Krosmoz.Infrastructure.AppHost/Krosmoz.Infrastructure.AppHost.csproj
+++ b/infrastructure/Krosmoz.Infrastructure.AppHost/Krosmoz.Infrastructure.AppHost.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0"/>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>b4c09ae8-77d1-4ba3-989f-6eb96ed3e683</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0"/>
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.3.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.Development.json">
+      <DependentUpon>appsettings.json</DependentUpon>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Krosmoz.Servers.AuthServer\Krosmoz.Servers.AuthServer.csproj"/>
+    <ProjectReference Include="..\..\src\Krosmoz.Servers.GameServer\Krosmoz.Servers.GameServer.csproj"/>
+    <ProjectReference Include="..\..\tools\Krosmoz.Tools.Database\Krosmoz.Tools.Database.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/infrastructure/Krosmoz.Infrastructure.AppHost/Properties/launchSettings.json
+++ b/infrastructure/Krosmoz.Infrastructure.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json.schemastore.org/launchsettings.json",
+    "profiles": {
+        "https": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "https://localhost:17097;http://localhost:15154",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_ENVIRONMENT": "Development",
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21200",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22085"
+            }
+        },
+        "http": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "http://localhost:15154",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_ENVIRONMENT": "Development",
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19215",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20146"
+            }
+        }
+    }
+}

--- a/infrastructure/Krosmoz.Infrastructure.AppHost/appsettings.Development.json
+++ b/infrastructure/Krosmoz.Infrastructure.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    }
+}

--- a/infrastructure/Krosmoz.Infrastructure.AppHost/appsettings.json
+++ b/infrastructure/Krosmoz.Infrastructure.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning",
+            "Aspire.Hosting.Dcp": "Warning"
+        }
+    }
+}

--- a/infrastructure/Krosmoz.Infrastructure.ServiceDefaults/Extensions.cs
+++ b/infrastructure/Krosmoz.Infrastructure.ServiceDefaults/Extensions.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Krosmoz.Infrastructure.ServiceDefaults;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation(tracing =>
+                        // Exclude health check requests from tracing
+                        tracing.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath)
+                    )
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks(HealthEndpointPath);
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks(AlivenessEndpointPath,
+                new HealthCheckOptions { Predicate = r => r.Tags.Contains("live") });
+        }
+
+        return app;
+    }
+}

--- a/infrastructure/Krosmoz.Infrastructure.ServiceDefaults/Krosmoz.Infrastructure.ServiceDefaults.csproj
+++ b/infrastructure/Krosmoz.Infrastructure.ServiceDefaults/Krosmoz.Infrastructure.ServiceDefaults.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Aspire.Npgsql" Version="9.3.0"/>
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.5.0"/>
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.0"/>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Krosmoz.Servers.AuthServer/Krosmoz.Servers.AuthServer.csproj
+++ b/src/Krosmoz.Servers.AuthServer/Krosmoz.Servers.AuthServer.csproj
@@ -9,8 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj" />
-    <ProjectReference Include="..\..\libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\infrastructure\Krosmoz.Infrastructure.ServiceDefaults\Krosmoz.Infrastructure.ServiceDefaults.csproj"/>
+    <ProjectReference Include="..\..\libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj"/>
+    <ProjectReference Include="..\..\libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Krosmoz.Servers.AuthServer/Program.cs
+++ b/src/Krosmoz.Servers.AuthServer/Program.cs
@@ -5,6 +5,7 @@ using Krosmoz.Core.Network.Framing;
 using Krosmoz.Core.Network.Transport;
 using Krosmoz.Core.Scheduling;
 using Krosmoz.Core.Services;
+using Krosmoz.Infrastructure.ServiceDefaults;
 using Krosmoz.Protocol.Datacenter;
 using Krosmoz.Protocol.Messages;
 using Krosmoz.Serialization.D2O.Abstractions;
@@ -18,10 +19,14 @@ using Krosmoz.Servers.AuthServer.Services.Servers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Logging.UseSerilog();
+
+builder.AddServiceDefaults()
+    .AddNpgsqlDataSource("Auth");
 
 builder.Services
     .Configure<TcpServerOptions>(builder.Configuration.GetSection("Server"))

--- a/src/Krosmoz.Servers.AuthServer/appsettings.json
+++ b/src/Krosmoz.Servers.AuthServer/appsettings.json
@@ -1,7 +1,4 @@
 ﻿{
-    "ConnectionStrings": {
-        "Auth": "Server=127.0.0.1;Port=5432;Database=krosmoz_auth;User Id=Developer;Password=i6tLkHC7Lz3TwDZg;Pooling=true;"
-    },
     "DetailedErrors": true,
     "Server": {
         "Host": "127.0.0.1",

--- a/src/Krosmoz.Servers.GameServer/Krosmoz.Servers.GameServer.csproj
+++ b/src/Krosmoz.Servers.GameServer/Krosmoz.Servers.GameServer.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj" />
-    <ProjectReference Include="..\..\libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\infrastructure\Krosmoz.Infrastructure.ServiceDefaults\Krosmoz.Infrastructure.ServiceDefaults.csproj"/>
+    <ProjectReference Include="..\..\libs\Krosmoz.Protocol\Krosmoz.Protocol.csproj"/>
+    <ProjectReference Include="..\..\libs\Krosmoz.SourceGeneration\Krosmoz.SourceGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Krosmoz.Servers.GameServer/Program.cs
+++ b/src/Krosmoz.Servers.GameServer/Program.cs
@@ -1,11 +1,11 @@
-﻿
-using Krosmoz.Core.Extensions;
+﻿using Krosmoz.Core.Extensions;
 using Krosmoz.Core.Network.Dispatcher;
 using Krosmoz.Core.Network.Factory;
 using Krosmoz.Core.Network.Framing;
 using Krosmoz.Core.Network.Transport;
 using Krosmoz.Core.Scheduling;
 using Krosmoz.Core.Services;
+using Krosmoz.Infrastructure.ServiceDefaults;
 using Krosmoz.Protocol.Datacenter;
 using Krosmoz.Protocol.Messages;
 using Krosmoz.Serialization.D2O.Abstractions;
@@ -27,32 +27,35 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-await Host.CreateDefaultBuilder(args)
-    .ConfigureLogging(static logging => logging.UseSerilog())
-    .ConfigureServices(static (context, services) =>
-    {
-        services
-            .Configure<TcpServerOptions>(context.Configuration.GetSection("Server"))
-            .AddDbContext<GameDbContext>(context.Configuration.GetConnectionString("Game"))
-            .AddTransient<DofusMessageDecoder>()
-            .AddTransient<DofusMessageEncoder>()
-            .AddTransient<IScheduler, Scheduler>()
-            .AddSingleton<IMessageFactory, MessageFactory>()
-            .AddSingleton<IDatacenterObjectFactory, DatacenterObjectFactory>()
-            .AddSingleton<IDatacenterRepository, DatacenterRepository>()
-            .AddSingleton<IBreedService, BreedService>()
-            .AddSingleton<IOptionalFeatureService, OptionalFeatureService>()
-            .AddSingleton<IGameService, GameService>()
-            .AddSingleton<IIpcService, IpcService>()
-            .AddSingleton<IAuthenticationService, AuthenticationService>()
-            .AddSingleton<ICharacterFactory, CharacterFactory>()
-            .AddSingleton<ICharacterNameGenerationService, CharacterNameGenerationService>()
-            .AddSingleton<ICharacterCreationService, CharacterCreationService>()
-            .AddSingleton<ICharacterRepository, CharacterRepository>()
-            .AddSingleton<ICharacterSelectionService, CharacterSelectionService>()
-            .AddSingleton<ICharacterDeletionService, CharacterDeletionService>()
-            .AddHostedServiceAsSingleton<GameServer>()
-            .AddMessageHandlers()
-            .AddInitializableServices();
-    })
-    .RunConsoleAsync();
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults()
+    .AddNpgsqlDataSource("Game");
+
+builder.Logging.UseSerilog();
+
+builder.Services
+    .Configure<TcpServerOptions>(builder.Configuration.GetSection("Server"))
+    .AddDbContext<GameDbContext>(builder.Configuration.GetConnectionString("game"))
+    .AddTransient<DofusMessageDecoder>()
+    .AddTransient<DofusMessageEncoder>()
+    .AddTransient<IScheduler, Scheduler>()
+    .AddSingleton<IMessageFactory, MessageFactory>()
+    .AddSingleton<IDatacenterObjectFactory, DatacenterObjectFactory>()
+    .AddSingleton<IDatacenterRepository, DatacenterRepository>()
+    .AddSingleton<IBreedService, BreedService>()
+    .AddSingleton<IOptionalFeatureService, OptionalFeatureService>()
+    .AddSingleton<IGameService, GameService>()
+    .AddSingleton<IIpcService, IpcService>()
+    .AddSingleton<IAuthenticationService, AuthenticationService>()
+    .AddSingleton<ICharacterFactory, CharacterFactory>()
+    .AddSingleton<ICharacterNameGenerationService, CharacterNameGenerationService>()
+    .AddSingleton<ICharacterCreationService, CharacterCreationService>()
+    .AddSingleton<ICharacterRepository, CharacterRepository>()
+    .AddSingleton<ICharacterSelectionService, CharacterSelectionService>()
+    .AddSingleton<ICharacterDeletionService, CharacterDeletionService>()
+    .AddHostedServiceAsSingleton<GameServer>()
+    .AddMessageHandlers()
+    .AddInitializableServices();
+
+builder.Build().Run();

--- a/src/Krosmoz.Servers.GameServer/appsettings.json
+++ b/src/Krosmoz.Servers.GameServer/appsettings.json
@@ -1,7 +1,4 @@
 ﻿{
-    "ConnectionStrings": {
-        "Game": "Server=127.0.0.1;Port=5432;Database=krosmoz_game;User Id=Developer;Password=i6tLkHC7Lz3TwDZg;Pooling=true;"
-    },
     "Server": {
         "Host": "127.0.0.1",
         "Port": 5556,

--- a/tools/Krosmoz.Tools.Database/Krosmoz.Tools.Database.csproj
+++ b/tools/Krosmoz.Tools.Database/Krosmoz.Tools.Database.csproj
@@ -8,14 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Krosmoz.Servers.AuthServer\Krosmoz.Servers.AuthServer.csproj" />
-    <ProjectReference Include="..\..\src\Krosmoz.Servers.GameServer\Krosmoz.Servers.GameServer.csproj" />
+    <ProjectReference Include="..\..\src\Krosmoz.Servers.AuthServer\Krosmoz.Servers.AuthServer.csproj"/>
+    <ProjectReference Include="..\..\src\Krosmoz.Servers.GameServer\Krosmoz.Servers.GameServer.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/tools/Krosmoz.Tools.Database/Program.cs
+++ b/tools/Krosmoz.Tools.Database/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Krosmoz.Core.Extensions;
+using Krosmoz.Infrastructure.ServiceDefaults;
 using Krosmoz.Protocol.Datacenter;
 using Krosmoz.Serialization.D2O.Abstractions;
 using Krosmoz.Serialization.Repository;
@@ -13,18 +14,21 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-await Host.CreateDefaultBuilder(args)
-    .ConfigureLogging(static logging => logging.UseSerilog())
-    .ConfigureServices(static (context, services) =>
-    {
-        services
-            .AddDbContext<AuthDbContext>(context.Configuration.GetConnectionString("Auth"))
-            .AddDbContext<GameDbContext>(context.Configuration.GetConnectionString("Game"))
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults()
+    .AddNpgsqlDataSource("Game");
+
+builder.Logging.UseSerilog();
+
+builder.Services
+            .AddDbContext<AuthDbContext>(builder.Configuration.GetConnectionString("Auth"))
+            .AddDbContext<GameDbContext>(builder.Configuration.GetConnectionString("Game"))
             .AddSingleton<IDatacenterObjectFactory, DatacenterObjectFactory>()
             .AddSingleton<IDatacenterRepository, DatacenterRepository>()
             .AddSingleton<BaseSynchronizer, ServerSynchronizer>()
             .AddSingleton<BaseSynchronizer, MapSynchronizer>()
             .AddSingleton<BaseSynchronizer, ExperienceSynchronizer>()
             .AddHostedService<SynchronizerHostedService>();
-    })
-    .RunConsoleAsync();
+
+builder.Build().Run();

--- a/tools/Krosmoz.Tools.Database/appsettings.json
+++ b/tools/Krosmoz.Tools.Database/appsettings.json
@@ -1,6 +1,0 @@
-﻿{
-    "ConnectionStrings": {
-        "Auth": "Server=127.0.0.1;Port=5432;Database=krosmoz_auth;User Id=Developer;Password=i6tLkHC7Lz3TwDZg;Pooling=true;",
-        "Game": "Server=127.0.0.1;Port=5432;Database=krosmoz_game;User Id=Developer;Password=i6tLkHC7Lz3TwDZg;Pooling=true;"
-    }
-}


### PR DESCRIPTION
Added .NET Aspire 9.3 as Infrastructure Orchestrator and moved the mandatory stuff to work with it.
Allow trace, metrics (...)

Moved shared service configurations into a new infrastructure layer with `Krosmoz.Infrastructure.ServiceDefaults` and updated dependencies accordingly. Refactored `Program.cs` files for consistency, adopting a unified service setup using `AddServiceDefaults`. Simplified database configuration and removed sensitive connection strings from appsettings files.